### PR TITLE
go.modのgoバージョン指定を1.23.4から1.23に修正

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -1,5 +1,5 @@
 module postgres-replication-demo
 
-go 1.23.4
+go 1.23
 
 require github.com/lib/pq v1.10.9


### PR DESCRIPTION
## 概要
- go.modのgoディレクティブをからに修正しました。

## 理由
- Go公式の推奨に従い、go.modのバージョン指定はメジャー.マイナー（例: 1.23）までとするのが一般的なためです。
- パッチバージョン（3桁目）はgo.modでは意味を持たず、Goツールチェーンも2桁で解釈します。
- 参考: [Go Modules Reference - The go directive](https://go.dev/ref/mod#go-directive)

## 補足
- 機能的な変更はありません。ビルドや動作への影響もありません。